### PR TITLE
fix download redis base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Default 'undef' results to 'root' as redis system group
 ##### `download_base`
 
 Url where to find the source tar.gz.
-Default value is 'http://download.redis.io/releases'
+Default value is 'http://download.redis.io'
 
 #### Defined Type: `redis::server`
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,7 +21,7 @@
 #   The redis system group. Default value is 'undef', which results to 'root' as system group.
 #
 # [*download_base*]
-#   Url where to find the source tar.gz. Default value is 'http://download.redis.io/releases'
+#   Url where to find the source tar.gz. Default value is 'http://download.redis.io'
 #
 class redis::install (
   $redis_version     = $::redis::params::redis_version,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,5 +8,5 @@ class redis::params {
   $download_tool         = 'curl -s -L'
   $redis_user            = undef
   $redis_group           = undef
-  $download_base         = 'http://download.redis.io/releases'
+  $download_base         = 'http://download.redis.io'
 }


### PR DESCRIPTION
The base url for the latest stable redis version has been changed. Source: https://redis.io/download/#latest-stable